### PR TITLE
fix: menu indentation, code align and others

### DIFF
--- a/blubook.css
+++ b/blubook.css
@@ -203,7 +203,7 @@ ul>li>ul>li>ul>li {
 }
 
 ol,
-ul:not(#sidebar-files-menu,#context-menu) {
+ul:not(#sidebar-files-menu,#context-menu,.outline-children) {
   padding-left: 2rem;
   line-height: 1;
 }
@@ -451,8 +451,12 @@ tt {
   font-size: 1.1rem !important;/* Fix view mode alignment issue */
   background: #f5f7f9;
   display: inline;
-  vertical-align: text-top;
+  vertical-align: top;
   line-height: 1.8;
+}
+
+#write table code{
+  vertical-align: baseline;
 }
 
 #write span[md-inline='highlight'] code{
@@ -465,6 +469,7 @@ tt {
 
 #write *[mdtype="heading"] code{
   font-size: inherit!important;
+  vertical-align: baseline;
 }
 
 #write .md-footnote {
@@ -520,6 +525,10 @@ tt {
 #typora-sidebar *,
 #typora-quick-open{
   color: #f0f0f0;
+}
+
+.typora-quick-open-item-path{/* file path in the Quick open panel*/
+  white-space: nowrap;
 }
 
 #typora-sidebar .file-tree-node.file-library-file-node.active .file-node-background {
@@ -1005,6 +1014,11 @@ pre.md-fences[lang=mermaid].md-focus .md-diagram-panel {
   color: #fff;
 }
 
+.ty-input.ty-input-after.ty-cm-lang-input::selection,
+.ty-input.ty-input-after.ty-cm-lang-input::-webkit-selection{
+  color: #000000;
+}
+
 .enable-diagrams pre.md-fences[lang=sequence] .code-tooltip,
 .enable-diagrams pre.md-fences[lang=flow] .code-tooltip,
 .enable-diagrams pre.md-fences[lang=mermaid] .code-tooltip {
@@ -1012,7 +1026,7 @@ pre.md-fences[lang=mermaid].md-focus .md-diagram-panel {
   bottom: -2.2em;
 }
 
-/****** Windows contral ******/
+/****** Windows control ******/
 .megamenu-menu-list li a.active,
 .megamenu-menu-list:not(.saved) li a:hover {
   background-color: #285e8e;


### PR DESCRIPTION
<details>
<summary>Menu indentation</summary>

![image](https://user-images.githubusercontent.com/51501079/126634899-6e4ce79e-bd5b-4e4f-bab8-b8fe39690ab7.png)

</details>

<details>
<summary>Code align</summary>

1. ![image](https://user-images.githubusercontent.com/51501079/126635000-3fa813d5-6dac-4c18-a331-2693520df3cc.png)
2. ![image](https://user-images.githubusercontent.com/51501079/126635045-a1bc19fe-f975-49d3-92d4-4321f7420fdf.png)
3. ![image](https://user-images.githubusercontent.com/51501079/126635071-fc6ebdb7-e285-432b-a974-5d9447585301.png)

</details>

<details>
<summary>File path in quick open panel</summary>

![Untitled](https://user-images.githubusercontent.com/51501079/126635525-b17af52a-ec8a-4ab6-a002-21dc25872f6a.png)

</details>

<details>
<summary>Font color</summary>

![image](https://user-images.githubusercontent.com/51501079/126635735-c7f5b5eb-47de-4bd1-8058-ab620c99c37e.png)

</details>